### PR TITLE
Add push intent & tile service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,10 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity>
 
         <activity android:name=".SettingsActivity" android:exported="false" />
@@ -36,6 +40,22 @@
             android:name=".ProxyService"
             android:exported="false"
             android:foregroundServiceType="specialUse" />
+
+        <service
+            android:name=".ProxyTileService"
+            android:label="@string/app_name"
+            android:icon="@android:drawable/ic_menu_manage"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
+            android:exported="true"
+            tools:targetApi="24">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.service.quicksettings.TOGGLEABLE_TILE"
+                android:value="true" />
+        </service>
 
     </application>
 </manifest>

--- a/app/src/main/java/com/vkturn/proxy/MainActivity.kt
+++ b/app/src/main/java/com/vkturn/proxy/MainActivity.kt
@@ -25,6 +25,10 @@ class MainActivity : AppCompatActivity() {
     private lateinit var logScrollView: ScrollView
     private lateinit var btnToggle: Button
 
+    private fun updateToggleButton(isRunning: Boolean = ProxyService.isRunning) {
+        btnToggle.text = if (isRunning) "ОСТАНОВИТЬ ПРОКСИ" else "ЗАПУСТИТЬ ПРОКСИ"
+    }
+
     // Обработка выбора файла для обновления ядра
     private val filePicker = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
         if (result.resultCode == Activity.RESULT_OK) {
@@ -143,8 +147,8 @@ class MainActivity : AppCompatActivity() {
 
                 checkPermissionsAndStart()
             } else {
-                stopService(Intent(this, ProxyService::class.java))
-                btnToggle.text = "ЗАПУСТИТЬ ПРОКСИ"
+                ProxyService.stopProxy(this)
+                updateToggleButton(false)
             }
         }
     }
@@ -156,14 +160,13 @@ class MainActivity : AppCompatActivity() {
                 return
             }
         }
-        ProxyService.logBuffer.clear()
-        startForegroundService(Intent(this, ProxyService::class.java))
-        btnToggle.text = "ОСТАНОВИТЬ ПРОКСИ"
+        ProxyService.startProxy(this)
+        updateToggleButton(true)
     }
 
     override fun onResume() {
         super.onResume()
-        btnToggle.text = if (ProxyService.isRunning) "ОСТАНОВИТЬ ПРОКСИ" else "ЗАПУСТИТЬ ПРОКСИ"
+        updateToggleButton()
         tvLogs.text = ProxyService.logBuffer.joinToString("\n")
         scrollLogsToEnd()
 
@@ -172,6 +175,11 @@ class MainActivity : AppCompatActivity() {
                 if (tvLogs.text.length > 25000) tvLogs.text = tvLogs.text.substring(10000)
                 tvLogs.append("\n$msg")
                 scrollLogsToEnd()
+            }
+        }
+        ProxyService.onStateChanged = { isRunning ->
+            runOnUiThread {
+                updateToggleButton(isRunning)
             }
         }
     }
@@ -183,5 +191,6 @@ class MainActivity : AppCompatActivity() {
     override fun onPause() {
         super.onPause()
         ProxyService.onLogReceived = null
+        ProxyService.onStateChanged = null
     }
 }

--- a/app/src/main/java/com/vkturn/proxy/ProxyService.kt
+++ b/app/src/main/java/com/vkturn/proxy/ProxyService.kt
@@ -2,12 +2,15 @@ package com.vkturn.proxy
 
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.app.Service
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.IBinder
 import android.os.PowerManager
+import android.service.quicksettings.TileService
 import androidx.core.app.NotificationCompat
 import java.io.BufferedReader
 import java.io.File
@@ -20,11 +23,50 @@ class ProxyService : Service() {
         var isRunning = false
         val logBuffer = mutableListOf<String>()
         var onLogReceived: ((String) -> Unit)? = null
+        var onStateChanged: ((Boolean) -> Unit)? = null
 
         fun addLog(msg: String) {
             if (logBuffer.size > 200) logBuffer.removeAt(0)
             logBuffer.add(msg)
             onLogReceived?.invoke(msg)
+        }
+
+        private fun notifyStateChanged(isRunning: Boolean) {
+            onStateChanged?.invoke(isRunning)
+        }
+
+        fun startProxy(context: Context) {
+            logBuffer.clear()
+
+            val intent = Intent(context, ProxyService::class.java)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent)
+            } else {
+                context.startService(intent)
+            }
+        }
+
+        fun stopProxy(context: Context) {
+            context.stopService(Intent(context, ProxyService::class.java))
+        }
+
+        fun toggleProxy(context: Context): Boolean {
+            return if (isRunning) {
+                stopProxy(context)
+                false
+            } else {
+                startProxy(context)
+                true
+            }
+        }
+
+        fun requestTileRefresh(context: Context) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) return
+
+            TileService.requestListeningState(
+                context,
+                ComponentName(context.packageName, "${context.packageName}.ProxyTileService")
+            )
         }
     }
 
@@ -44,13 +86,29 @@ class ProxyService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         if (isRunning) return START_STICKY
 
+        val openAppIntent = Intent(this, MainActivity::class.java).apply {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        }
+        val pendingIntentFlags = PendingIntent.FLAG_UPDATE_CURRENT or
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) PendingIntent.FLAG_IMMUTABLE else 0
+        val openAppPendingIntent = PendingIntent.getActivity(this, 0, openAppIntent, pendingIntentFlags)
+
         val notification = NotificationCompat.Builder(this, "ProxyChannel")
             .setContentTitle("VK TURN Proxy")
             .setContentText("Работает в фоне")
             .setSmallIcon(android.R.drawable.ic_menu_preferences)
+            .setContentIntent(openAppPendingIntent)
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setAutoCancel(false)
             .build()
         startForeground(1, notification)
         isRunning = true
+        notifyStateChanged(true)
+        requestTileRefresh(this)
 
         val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
         wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "VkTurn::BgLock")
@@ -134,8 +192,10 @@ class ProxyService : Service() {
     override fun onDestroy() {
         super.onDestroy()
         isRunning = false
+        notifyStateChanged(false)
         addLog("=== ОСТАНОВКА ИЗ ИНТЕРФЕЙСА ===")
         process?.destroy()
         if (wakeLock?.isHeld == true) wakeLock?.release()
+        requestTileRefresh(this)
     }
 }

--- a/app/src/main/java/com/vkturn/proxy/ProxyTileService.kt
+++ b/app/src/main/java/com/vkturn/proxy/ProxyTileService.kt
@@ -1,0 +1,51 @@
+package com.vkturn.proxy
+
+import android.graphics.drawable.Icon
+import android.os.Build
+import android.service.quicksettings.Tile
+import android.service.quicksettings.TileService
+
+class ProxyTileService : TileService() {
+
+    override fun onTileAdded() {
+        super.onTileAdded()
+        updateTile()
+    }
+
+    override fun onStartListening() {
+        super.onStartListening()
+        updateTile()
+    }
+
+    override fun onClick() {
+        super.onClick()
+
+        val toggleAction = Runnable {
+            val isRunning = ProxyService.toggleProxy(this)
+            updateTile(isRunning)
+        }
+
+        if (isSecure && isLocked) {
+            unlockAndRun(toggleAction)
+        } else {
+            toggleAction.run()
+        }
+    }
+
+    private fun updateTile(isRunningOverride: Boolean? = null) {
+        val tile = qsTile ?: return
+        val isRunning = isRunningOverride ?: ProxyService.isRunning
+
+        tile.label = getString(R.string.app_name)
+        tile.state = if (isRunning) Tile.STATE_ACTIVE else Tile.STATE_INACTIVE
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            tile.subtitle = getString(
+                if (isRunning) R.string.qs_tile_state_running else R.string.qs_tile_state_stopped
+            )
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            tile.icon = Icon.createWithResource(this, android.R.drawable.ic_menu_manage)
+        }
+        tile.updateTile()
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
     <string name="app_name">VkTurnProxy</string>
+    <string name="qs_tile_state_running">Прокси включен</string>
+    <string name="qs_tile_state_stopped">Прокси выключен</string>
 </resources>


### PR DESCRIPTION
Может быть это будет интересно.
Для меня было неудобно, что нет возможности через push перейти в приложение.
Также, в плитках, как мне кажется, будет удобно расположить wg и vkturnproxy, и включать/выключать их двумя нажатиями кнопок.
Компиляция успешна, проверял работоспособность на Android 16. Оставил ветку открытой, вдруг захочется что - то исправить.

P.S.: проблема, которая звучит как "ядро умерло, но сервис продолжает работать" все еще активна в данном сценарии. Tile Service и его иконка привязан именно к состоянию Foreground service Android, но не so-шки.