### PR TITLE
ci: Add GitHub action

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,250 @@
+name: Android CI
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      build_type:
+        description: Тип APK для ручной сборки
+        required: true
+        default: release
+        type: choice
+        options:
+          - release
+          - debug
+
+jobs:
+  debug:
+    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.build_type == 'debug')
+    name: Build Debug APK
+    runs-on: ubuntu-latest
+    steps:
+      - name: Проверка кода
+        uses: actions/checkout@v6
+
+      - name: Настройка Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+
+      - name: Загрузка libvkturn.so
+        run: |
+          mkdir -p app/src/main/jniLibs/arm64-v8a
+          curl -fL \
+            https://github.com/cacggghp/vk-turn-proxy/releases/latest/download/client-android-arm64 \
+            -o app/src/main/jniLibs/arm64-v8a/libvkturn.so
+
+      - name: Сборка debug APK
+        run: sh gradlew assembleDebug
+
+      - name: Загрузка debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug
+          path: app/build/outputs/apk/debug/app-debug.apk
+
+  build:
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.build_type == 'release')
+    name: Build Signed Release APK
+    runs-on: ubuntu-latest
+    steps:
+      - name: Проверка кода
+        uses: actions/checkout@v6
+
+      - name: Настройка Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+
+      - name: Загрузка libvkturn.so
+        run: |
+          mkdir -p app/src/main/jniLibs/arm64-v8a
+          curl -fL \
+            https://github.com/cacggghp/vk-turn-proxy/releases/latest/download/client-android-arm64 \
+            -o app/src/main/jniLibs/arm64-v8a/libvkturn.so
+
+      - name: Подготовка keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          if [ -z "$ANDROID_KEYSTORE_BASE64" ]; then
+            echo "Секрет ANDROID_KEYSTORE_BASE64 не задан."
+            exit 1
+          fi
+
+          mkdir -p "$RUNNER_TEMP/android-signing"
+          printf '%s' "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/android-signing/release.jks"
+
+      - name: Сборка release APK
+        env:
+          ANDROID_KEYSTORE_PATH: ${{ runner.temp }}/android-signing/release.jks
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          if [ -z "$ANDROID_KEYSTORE_PASSWORD" ] || [ -z "$ANDROID_KEY_ALIAS" ] || [ -z "$ANDROID_KEY_PASSWORD" ]; then
+            echo "Не заданы секреты для подписи Android."
+            exit 1
+          fi
+
+          sh gradlew assembleRelease
+
+      - name: Загрузка release APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release
+          path: app/build/outputs/apk/release/app-release.apk
+
+  release:
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.build_type == 'release')
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Проверка кода
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Загрузка release APK
+        uses: actions/download-artifact@v4
+        with:
+          name: app-release
+          path: dist
+
+      - name: Подготовка данных релиза
+        id: meta
+        run: |
+          LATEST_TAG="$(git tag -l | grep -E '^(v)?[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1 || true)"
+          PREFIX=""
+          BASE_VERSION="$LATEST_TAG"
+
+          if [ -z "$LATEST_TAG" ]; then
+            BASE_VERSION="0.0.0"
+          elif [ "${LATEST_TAG#v}" != "$LATEST_TAG" ]; then
+            PREFIX="v"
+            BASE_VERSION="${LATEST_TAG#v}"
+          fi
+
+          IFS=. read -r MAJOR MINOR PATCH <<< "$BASE_VERSION"
+
+          if [ -n "$LATEST_TAG" ]; then
+            RANGE="$LATEST_TAG..HEAD"
+          else
+            RANGE="HEAD"
+          fi
+
+          COMMITS="$(git log --no-merges --format='%s' "$RANGE")"
+          BUMP=""
+
+          if printf '%s\n' "$COMMITS" | grep -Eiq '^break([(:! ]|$)'; then
+            BUMP="major"
+            MAJOR=$((MAJOR + 1))
+            MINOR=0
+            PATCH=0
+          elif printf '%s\n' "$COMMITS" | grep -Eiq '^feat([(:! ]|$)'; then
+            BUMP="minor"
+            MINOR=$((MINOR + 1))
+            PATCH=0
+          elif printf '%s\n' "$COMMITS" | grep -Eiq '^fix([(:! ]|$)'; then
+            BUMP="patch"
+            PATCH=$((PATCH + 1))
+          fi
+
+          NEXT_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          NEXT_TAG="${PREFIX}${NEXT_VERSION}"
+
+          {
+            echo "previous_tag=$LATEST_TAG"
+            echo "range=$RANGE"
+            echo "bump=$BUMP"
+            echo "should_release=$([ -n "$BUMP" ] && echo true || echo false)"
+            echo "tag_name=$NEXT_TAG"
+            echo "release_name=$NEXT_TAG"
+            echo "apk_name=vkturn-${NEXT_TAG}.apk"
+            echo "body_path=release-notes.md"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Формирование заметок к релизу
+        id: notes
+        if: steps.meta.outputs.should_release == 'true'
+        env:
+          PREVIOUS_TAG: ${{ steps.meta.outputs.previous_tag }}
+          NEXT_TAG: ${{ steps.meta.outputs.tag_name }}
+          RANGE: ${{ steps.meta.outputs.range }}
+        run: |
+          strip_prefix() {
+            sed -E 's/^(feat|fix|break)([(!:]|[[:space:]])+[[:space:]]*//I'
+          }
+
+          FEATURES="$(git log --no-merges --format='%s (%h)' "$RANGE" | grep -Ei '^feat([(:! ]|$)' | strip_prefix | LC_ALL=C sort -f || true)"
+          FIXES="$(git log --no-merges --format='%s (%h)' "$RANGE" | grep -Ei '^fix([(:! ]|$)' | strip_prefix | LC_ALL=C sort -f || true)"
+          BREAKING="$(git log --no-merges --format='%s (%h)' "$RANGE" | grep -Ei '^break([(:! ]|$)' | strip_prefix | LC_ALL=C sort -f || true)"
+
+          {
+            echo "body_path=release-notes.md"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            if [ -n "$BREAKING" ]; then
+              echo "### Несовместимые изменения"
+              echo
+              printf '%s\n' "$BREAKING" | sed 's/^/- /'
+              echo
+            fi
+
+            if [ -n "$FEATURES" ]; then
+              echo "### Новые функции"
+              echo
+              printf '%s\n' "$FEATURES" | sed 's/^/- /'
+              echo
+            fi
+
+            if [ -n "$FIXES" ]; then
+              echo "### Исправление багов"
+              echo
+              printf '%s\n' "$FIXES" | sed 's/^/- /'
+              echo
+            fi
+          } > release-notes.md
+
+      - name: Переименование release APK
+        if: steps.meta.outputs.should_release == 'true'
+        env:
+          APK_NAME: ${{ steps.meta.outputs.apk_name }}
+        run: mv dist/app-release.apk "dist/$APK_NAME"
+
+      - name: Создание релиза
+        if: steps.meta.outputs.should_release == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/${{ steps.meta.outputs.apk_name }}
+          tag_name: ${{ steps.meta.outputs.tag_name }}
+          target_commitish: ${{ github.sha }}
+          name: ${{ steps.meta.outputs.release_name }}
+          body_path: ${{ steps.meta.outputs.body_path }}
+          overwrite_files: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Пропуск релиза без семантических коммитов
+        if: steps.meta.outputs.should_release != 'true'
+        run: |
+          echo "Новый релиз не создан."
+          echo "После последнего тега не найдено коммитов с префиксами break, feat или fix."

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ local.properties
 # Build outputs
 **/build/
 **/release/
+
+# CI/local native binary copied from upstream vk-turn-proxy releases
+/app/src/main/jniLibs/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,16 @@ plugins {
     alias(libs.plugins.kotlin.android)
 }
 
+val signingKeystorePath = System.getenv("ANDROID_KEYSTORE_PATH")
+val signingKeystorePassword = System.getenv("ANDROID_KEYSTORE_PASSWORD")
+val signingKeyAlias = System.getenv("ANDROID_KEY_ALIAS")
+val signingKeyPassword = System.getenv("ANDROID_KEY_PASSWORD")
+val hasReleaseSigning =
+    !signingKeystorePath.isNullOrBlank() &&
+        !signingKeystorePassword.isNullOrBlank() &&
+        !signingKeyAlias.isNullOrBlank() &&
+        !signingKeyPassword.isNullOrBlank()
+
 android {
     namespace = "com.vkturn.proxy"
     compileSdk = 36
@@ -21,11 +31,24 @@ android {
         resources.excludes += "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
         jniLibs.useLegacyPackaging = true
     }
-    // ---------------------------------
+
+    signingConfigs {
+        if (hasReleaseSigning) {
+            create("release") {
+                storeFile = file(signingKeystorePath!!)
+                storePassword = signingKeystorePassword
+                keyAlias = signingKeyAlias
+                keyPassword = signingKeyPassword
+            }
+        }
+    }
 
     buildTypes {
         release {
             isMinifyEnabled = false
+            if (hasReleaseSigning) {
+                signingConfig = signingConfigs.getByName("release")
+            }
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"


### PR DESCRIPTION
Применена правильная политика для семантичсеких релизов.

Теперь релизы автоматически поступают при пуше коммитов в main от бота github-actions, если задать одно из трёх семантических сообщений: break, feat, fix.

Логика bump такая:
break: Commit message -> major
feat: Commit message -> minor
fix: Commit message -> patch

Версия релиза теперь вычисляется семантически от последнего существующего тега формата major.minor.patch (1.2.3 или v1.2.3).

В релизе будет только "Commit message". Пример: https://github.com/alexmac6574/vk-turn-proxy-android/releases

Обязательно нужно писать смысловые коммиты, иначе в релизах будет хаос. При мердже PR (пулл реквестов) нужно использовать "squash and merge", а не обычный мердж и обязательно адекватное сообщение. Если нужно закоммитить без релиза, можно написать любое сообщение, не используя break, feat, fix в начале коммита. Другие семантические сообщения по конвенции - ci, build, chore, refactor и т.д. А лучше пушить код в ветку dev, тестировать и потом пушить в main.

___

Для запуска нужно добавить секреты в репозиторий:
ANDROID_KEYSTORE_BASE64
ANDROID_KEYSTORE_PASSWORD
ANDROID_KEY_ALIAS
ANDROID_KEY_PASSWORD

Пример создания keystore (macOS / Linux)
```bash
keytool -genkeypair \
  -v \
  -keystore ~/android-signing/vk-turn-proxy-android.jks \
  -storepass ANDROID_KEYSTORE_PASSWORD \
  -alias ANDROID_KEY_ALIAS \
  -keypass ANDROID_KEY_PASSWORD \
  -keyalg RSA \
  -keysize 4096 \
  -sigalg SHA256withRSA \
  -validity 3650
```

Все секреты задаются в команде, кроме ANDROID_KEYSTORE_BASE64, чтобы получить этот секрет, нужно получить base64 сгенерированного keystore:
macOS
```
base64 < ~/android-signing/vk-turn-proxy-android.jks | pbcopy
```
Linux
```
base64 -w 0 ~/android-signing/vk-turn-proxy-android.jks
```

Эти секреты так же можно указать, как environment variables и APK. будет автоматически подписываться при gradle.
___

В приложении срочно нужно адресовать все уязвимости. Ради интереса, я попытался что-то сделать [в этой ветке](https://github.com/alexmac6574/vk-turn-proxy-android/tree/ql), это исправило эти уязвимости:
CVE-2021-33813 / GHSA-2363-cqg2-863c
CVE-2024-29371 / GHSA-3677-xxcr-wjqv
CVE-2024-26308 / GHSA-4265-ccf5-phj5
CVE-2025-48924 / GHSA-j288-q9x7-2f5v
CVE-2024-25710 / GHSA-4g9r-vxhx-9pgx

Но это костыльное решение и я не тестировал рабтоспособность, поэтому без PR. Остаётся ещё 14 уязвимостей. 

Просьба, загрузите код последних версий, я так предполагаю он отсуствует в репозитории?